### PR TITLE
Allow disabling TLS hostname verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ type = radicale_imap
 # Use StartTLS to secure the connection
 # Requires Python >= 3.4
 #imap_secure = True
+
+# Check TLS hostname matches
+# Requires Python >= 3.4, and imap_secure = True
+#imap_secure_check_hostname = True
 ```
 
 ## License

--- a/radicale_imap/__init__.py
+++ b/radicale_imap/__init__.py
@@ -42,6 +42,9 @@ class Auth(BaseAuth):
         secure = True
         if self.configuration.has_option("auth", "imap_secure"):
             secure = self.configuration.getboolean("auth", "imap_secure")
+        secure_check_hostname = True
+        if self.configuration.has_option("auth", "imap_secure_check_hostname"):
+            secure_check_hostname = self.configuration.getboolean("auth", "imap_secure_check_hostname")
         try:
             if ":" in host:
                 address, port = host.rsplit(":", maxsplit=1)
@@ -59,7 +62,9 @@ class Auth(BaseAuth):
                 if sys.version_info < (3, 4):
                     connection.starttls()
                 else:
-                    connection.starttls(ssl.create_default_context())
+                    context = ssl.create_default_context()
+                    context.check_hostname = secure_check_hostname
+                    connection.starttls(context)
             except (imaplib.IMAP4.error, ssl.CertificateError) as e:
                 if secure:
                     raise


### PR DESCRIPTION
This adds a new configuration option to disable TLS hostname verification. This allows for configuring TLS to be on, but pointed at `localhost` - even though the IMAP servers TLS cert doesn't contain a `localhost` as a SAN or CN.