### PR TITLE
Add support for "anycert" option to disable peer verification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ type = radicale_imap
 #imap_host =
 
 # Secure the IMAP connection
-# Value: tls | starttls | none
+# Value: tls | tls:anycert | starttls | starttls:anycert | none
 #imap_security = tls
 ```
 


### PR DESCRIPTION
Add support for ":anycert" suffix flag for configuration option "imap_security". This flag turns peer certificate verification off to support IMAP servers with TLS enabled but unverifiable certificate (e.g. self-signed).