### PR TITLE
Use AUTHENTICATE PLAIN instead of LOGIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# ⛔️ DEPRECATED
+# ⛔️ (Almost) DEPRECATED
 
 This feature has been integrated into Radicale as of version 3.4.1.
+
+The PR to add AUTHENTICATE PLAIN has not, so use this with Radicale 3.4.0 if needed.
 
 # Radicale IMAP
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# ⛔️ (Almost) DEPRECATED
+# ⛔️ DEPRECATED
 
-This feature has been integrated into Radicale as of version 3.4.1.
+RadicaleIMAP has been integrated into Radicale as of version 3.4.1.
 
-The PR to add AUTHENTICATE PLAIN has not, so use this with Radicale 3.4.0 if needed.
+This fork was created to support UTF-8 in IMAP authentication, and
+the commit for that was merged to Radicale 3.5.0.
+
+So this repo here is of use to you only if you need Radicale version
+3.4.0 or less. It will conflict with Radicale 3.4.1.
 
 # Radicale IMAP
 

--- a/radicale_imap/__init__.py
+++ b/radicale_imap/__init__.py
@@ -71,7 +71,10 @@ class Auth(BaseAuth):
                 if security == "starttls":
                     connection.starttls(ssl.create_default_context())
             try:
-                connection.login(login, password)
+                connection.authenticate(
+                    "PLAIN",
+                    lambda _: "{0}\x00{0}\x00{1}".format(login, password).encode()
+                )
             except imaplib.IMAP4.error as e:
                 logger.debug(
                     "IMAP authentication failed: %s", e, exc_info=True)


### PR DESCRIPTION
Makes imaplib use more modern AUTHENTICATE verb
rather than LOGIN.
The immediate benefit is that now the credentials
can be non-ASCII.
In the future, it may be used to add other
authentication methods, such as OAuth.

References:
* https://datatracker.ietf.org/doc/html/rfc6855.html#page-5
* https://bugs.python.org/issue13700
