### PR TITLE
Publish to GitHub and PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+# ref: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish Package
+
+on:
+  # publish from the Releases page:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish Package
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v3
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build
+      run: python -m build
+
+    - name: Publish to Github
+      uses: softprops/action-gh-release@v1
+      with:
+        files: 'dist/*'
+        fail_on_unmatched_files: true
+        prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'dev') }}
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ IMAP authentication plugin for [Radicale](http://radicale.org/).
 ## Installation
 
 ```shell
-$ python3 -m pip install --upgrade https://github.com/Unrud/RadicaleIMAP/archive/master.tar.gz
+$ python3 -m pip install --upgrade RadicaleIMAP
 ```
 
 ## Configuration

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 VERSION = "3.0.0"
 
 setup(
-    name="Radicale_IMAP",
+    name="RadicaleIMAP",
     version=VERSION,
     description="IMAP authentication plugin for Radicale",
     author="Unrud",


### PR DESCRIPTION
I would really like to see a blessed IMAP plugin available for Radicale. There's a couple of forks/rewrites that are stealing your thunder:

* https://pypi.org/project/radicale-imap/
* https://pypi.org/project/radicale-imaps/

They don't seem to be well maintained, but they're on pypi so they have better visibility. The only way I found yours, which seems to be most official one (it [used to be part of Radicale v1](https://github.com/Kozea/Radicale/blob/v1/radicale/auth/IMAP.py)?), was because one of them mentioned it.

This GitHub Action builds wheels and sdists and pushes them to GitHub's releases page and PyPI. All you have to do is go to [New Release](https://github.com/Unrud/RadicaleIMAP/releases/new), fill in a version tag like "v0.9.1", click Publish, and a couple minutes later the .whl and .tar.gz will be up on [Releases](https://github.com/Unrud/RadicaleIMAP/releases).

To get PyPI working as well, [get a PyPI token](https://pypi.org/manage/account/token/), give it to GitHub [here](https://github.com/Unrud/RadicaleIMAP/settings/secrets/actions) named `PYPI_TOKEN`.

I recommend using a 'rc' tag like ["v0.9.1rc1"](https://peps.python.org/pep-0440/#pre-releases) to get the hang of the process (because you never can reuse tags on pypi).

To get a feel for it, you can see examples of how this looks in practice at

* https://github.com/kousu/radicale-bsdauth/actions

And the kinds of outputs it makes at

* https://github.com/kousu/radicale-bsdauth/releases
* https://pypi.org/project/radicale-bsdauth/