### PR TITLE
Implements domain allowance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.vscode

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ type = radicale_imap
 # Secure the IMAP connection
 # Value: tls | starttls | none
 #imap_security = tls
+
+# Domains allowed separated with comma
+# Syntax: domain[,domain]
+#    note: values are separated with comma
+# Default: ""
+#    note: empty value allow all domains to authenticate
+#allowed_domains = domain.tld, other.domain.org
 ```
 
 ## License

--- a/radicale_imap/__init__.py
+++ b/radicale_imap/__init__.py
@@ -89,6 +89,7 @@ class Auth(BaseAuth):
             if allowed_domains:
                 try:
                     if not email_domain(login) in allowed_domains:
+                        logger.debug("domain: %s is not allowed to login", email_domain(login))
                         return ""
                 except ValueError as e:
                     raise ValueError("failed to verify domain allowance: %r" % e)
@@ -103,13 +104,15 @@ class Auth(BaseAuth):
                 connection = imaplib.IMAP4(host=host, port=port)
                 if security == "starttls":
                     connection.starttls(ssl.create_default_context())
-                    
+
             try:
                 connection.login(login, password)
             except imaplib.IMAP4.error as e:
                 logger.debug("IMAP authentication failed: %s", e, exc_info=True)
                 return ""
             connection.logout()
+
+            logger.debug("user successfully authenticated: %s", login)
             return login
         except (OSError, imaplib.IMAP4.error) as e:
             raise RuntimeError(

--- a/radicale_imap/__init__.py
+++ b/radicale_imap/__init__.py
@@ -33,8 +33,10 @@ def imap_address(value):
     else:
         address, port = pre_address + pre_address_port, None
     try:
-        return (address.strip(string.whitespace + "[]"),
-                None if port is None else int(port))
+        return (
+            address.strip(string.whitespace + "[]"),
+            None if port is None else int(port),
+        )
     except ValueError:
         raise ValueError("malformed IMAP address: %r" % value)
 
@@ -45,9 +47,32 @@ def imap_security(value):
     return value
 
 
-PLUGIN_CONFIG_SCHEMA = {"auth": {
-    "imap_host": {"value": "", "type": imap_address},
-    "imap_security": {"value": "tls", "type": imap_security}}}
+def domain_list(domains):
+    if not domains:
+        return []
+    return [x.strip() for x in domains.split(",")]
+
+
+def email_domain(email):
+    try:
+        (emailuser, domain) = email.split("@")
+    except ValueError:
+        raise ValueError(
+            "invalid email address: failed to split email in two parts: %s" % email
+        )
+
+    if not emailuser or not domain:
+        raise ValueError("invalid email address: %s" % email)
+    return domain
+
+
+PLUGIN_CONFIG_SCHEMA = {
+    "auth": {
+        "imap_host": {"value": "", "type": imap_address},
+        "imap_security": {"value": "tls", "type": imap_security},
+        "allowed_domains": {"value": "", "type": domain_list},
+    }
+}
 
 
 class Auth(BaseAuth):
@@ -59,25 +84,35 @@ class Auth(BaseAuth):
     def login(self, login, password):
         host, port = self.configuration.get("auth", "imap_host")
         security = self.configuration.get("auth", "imap_security")
+        allowed_domains = self.configuration.get("auth", "allowed_domains")
         try:
+            if allowed_domains:
+                try:
+                    if not email_domain(login) in allowed_domains:
+                        return ""
+                except ValueError as e:
+                    raise ValueError("failed to verify domain allowance: %r" % e)
+
             if security == "tls":
                 port = 993 if port is None else port
                 connection = imaplib.IMAP4_SSL(
-                    host=host, port=port,
-                    ssl_context=ssl.create_default_context())
+                    host=host, port=port, ssl_context=ssl.create_default_context()
+                )
             else:
                 port = 143 if port is None else port
                 connection = imaplib.IMAP4(host=host, port=port)
                 if security == "starttls":
                     connection.starttls(ssl.create_default_context())
+                    
             try:
                 connection.login(login, password)
             except imaplib.IMAP4.error as e:
-                logger.debug(
-                    "IMAP authentication failed: %s", e, exc_info=True)
+                logger.debug("IMAP authentication failed: %s", e, exc_info=True)
                 return ""
             connection.logout()
             return login
         except (OSError, imaplib.IMAP4.error) as e:
-            raise RuntimeError("Failed to communicate with IMAP server %r: "
-                               "%s" % ("[%s]:%d" % (host, port), e)) from e
+            raise RuntimeError(
+                "Failed to communicate with IMAP server %r: "
+                "%s" % ("[%s]:%d" % (host, port), e)
+            ) from e

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,5 @@ setup(
     license="GNU GPL v3",
     platforms="Any",
     packages=["radicale_imap"],
-    install_requires=["radicale>=3.0.0"])
+    install_requires=["radicale>=3.0.0"],
+)

--- a/tests/radicale_imap_test.py
+++ b/tests/radicale_imap_test.py
@@ -1,0 +1,69 @@
+import unittest
+import radicale_imap
+import radicale.config
+
+# auth imap login should raise a runtime error
+# and it means that the plugin tries to log the user
+# against a non existent imap server which is great.
+#
+# this attribute is an alias for test readability
+# without rewriting the whole plugin with mockability
+TestIMAPSuccess = RuntimeError
+
+class TestRadicaleImap(unittest.TestCase):
+    def test_email_domain(self):
+        with self.assertRaises(ValueError):
+            radicale_imap.email_domain("invalid")
+
+        with self.assertRaises(ValueError):
+            radicale_imap.email_domain("invalid@domain@something")
+
+        self.assertEqual(radicale_imap.email_domain("valid@domain"), "domain")
+        self.assertEqual(
+            radicale_imap.email_domain("super.valid@domain.com"), "domain.com"
+        )
+
+    def test_auth_login(self):
+        auth = radicale_imap.Auth(radicale.config.load())
+        auth.configuration.update(
+            config={
+                "auth": {
+                    "allowed_domains": "test1.com, test2.com",
+                    "imap_host": "127.0.0.1:0000",
+                    "imap_security": "none",
+                }
+            }
+        )
+        with self.assertRaises(ValueError):
+            auth.login("invalid", "p@ssw0rd")
+
+        with self.assertRaises(TestIMAPSuccess):
+            auth.login("authorized@test1.com", "p@ssw0rd")
+
+        with self.assertRaises(TestIMAPSuccess):
+            auth.login("authorized@test2.com", "p@ssw0rd")
+
+        # test with empty allowed_domains
+        auth = radicale_imap.Auth(radicale.config.load())
+        auth.configuration.update(
+            config={
+                "auth": {
+                    "imap_host": "127.0.0.1:0000",
+                    "imap_security": "none",
+                }
+            }
+        )
+        with self.assertRaises(TestIMAPSuccess):
+            auth.login("authorized@test1.com", "p@ssw0rd")
+
+        auth.configuration.update(
+            config={
+                "auth": {
+                    "allowed_domains": "",
+                    "imap_host": "127.0.0.1:0000",
+                    "imap_security": "none",
+                }
+            }
+        )
+        with self.assertRaises(TestIMAPSuccess):
+            auth.login("authorized@test1.com", "p@ssw0rd")

--- a/tests/radicale_imap_test.py
+++ b/tests/radicale_imap_test.py
@@ -43,6 +43,9 @@ class TestRadicaleImap(unittest.TestCase):
         with self.assertRaises(TestIMAPSuccess):
             auth.login("authorized@test2.com", "p@ssw0rd")
 
+        # example.com is not an authorized domain
+        self.assertEqual(auth.login("unauthorized.domain@example.com", "p@ssw0rd"), "")
+
         # test with empty allowed_domains
         auth = radicale_imap.Auth(radicale.config.load())
         auth.configuration.update(


### PR DESCRIPTION
Hi :wave: 

Thanks a lot for this radicale plugin. I plan to use it for my own needs. I use it with a SaaS mail provider hosting thousands of emails and domains. Of course, I don't want anyone hosted on this provider to authenticated against my radicale instance.

This is why I implemented another configuration to allow specific email domains only. This was inspired by the [Gitea SMTP auth](https://docs.gitea.com/next/usage/authentication#smtp-simple-mail-transfer-protocol).

```ini
auth:
  allowed_domains = mydomain.tld, your.domain.tld
```

I took the liberty of adding some unit tests and to do some minor modifications (formatting, gitignore and adding some additionnal debugs)

Hope this pull request can help the community !
(please don't hesitate to critic my code, I'm not a python developer)

Have a great day !